### PR TITLE
1.0.6 - Competently actualize resource-sucking vortals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sprintpadawan",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Plan. Sprint. Repeat.",
   "private": true,
   "scripts": {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -68,7 +68,9 @@ const Navbar: React.FC<NavbarProps> = ({ title }) => {
                 </li>
               )}
               <li>
-                <a onClick={() => void signOut()}>Sign Out</a>
+                <a onClick={() => void signOut({ callbackUrl: "/" })}>
+                  Sign Out
+                </a>
               </li>
             </ul>
           </div>

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -18,7 +18,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   if (!session) {
     return {
       redirect: {
-        destination: "/",
+        destination: `/api/auth/signin?callbackUrl=${ctx.resolvedUrl}`,
         permanent: false,
       },
     };

--- a/src/pages/room/[id].tsx
+++ b/src/pages/room/[id].tsx
@@ -37,7 +37,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   if (!session) {
     return {
       redirect: {
-        destination: "/",
+        destination: `/api/auth/signin?callbackUrl=${ctx.resolvedUrl}`,
         permanent: false,
       },
     };

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -12,6 +12,7 @@ import { prisma } from "~/server/db";
 import type { Role } from "~/utils/types";
 import { sendMail } from "fms-ts";
 import { cacheClient, deleteFromCache } from "redicache-ts";
+import { redirect } from "next/navigation";
 
 const client = cacheClient(env.REDIS_URL);
 
@@ -75,7 +76,7 @@ export const authOptions: NextAuthOptions = {
     async signIn({}) {
       await deleteFromCache(client, env.APP_ENV, `kv_userlist_admin`);
     },
-    async signOut({}) {
+    async signOut() {
       await deleteFromCache(client, env.APP_ENV, `kv_userlist_admin`);
     },
   },


### PR DESCRIPTION
🐛 Sending room links to signed out users now redirects to the original link once the user signs in (In nerd speak: I added a proper callback URL for signin requests)